### PR TITLE
feat(picker): support onChange callback

### DIFF
--- a/lib/DatePicker.js
+++ b/lib/DatePicker.js
@@ -20,6 +20,7 @@ type Props = {
     headerFormat: string,
     confirmText: string,
     cancelText: string,
+    onChange: Function,
     onSelect: Function,
     onCancel: Function,
 }
@@ -118,7 +119,7 @@ class DatePicker extends Component<void, Props, State> {
      * @return {undefined}
      */
     handleDateSelect(value) {
-        this.setState({ value });
+        this.setState({ value }, () => this.props.onChange(value));
     }
 
     /**
@@ -198,12 +199,14 @@ class DatePicker extends Component<void, Props, State> {
                     ))}
                 </div>
                 <div className="datepicker-navbar">
-                    <a
+                    {confirmText && <a
                         className="datepicker-navbar-btn"
                         onClick={this.handleFinishBtnClick}>{confirmText}</a>
-                    <a
+                    }
+                    {cancelText && <a
                         className="datepicker-navbar-btn"
                         onClick={this.props.onCancel}>{cancelText}</a>
+                    }
                 </div>
             </div>
         );


### PR DESCRIPTION
In some cases it's a lot better to have a date picker that actually sets the underlying form data just as you scroll the wheels, without needing to actually press a "confirm" button. This is how the iOS date picker works in many cases (example: go to the iOS Contacts app and add a birthday to some contact). Maybe because of this, we were having many users having trouble using this picker in a mobile, because they don't tap "confirm" button, they just try to go to another field or things like that.

This is why I added two main changes in this PR:
- first is the support for a third `onChange` callback, that will get called on every picker selection
- being able to actually hide the cancel button by passing null as the `cancelText` prop (currently, passing null renders the button, just without text, which is maybe the worst option since its not useful)

With those two things I was able to customize the picker in a way that supports not needing to press the confirm button (passing a handler for the `onChange` new callback, and `null` as `cancelText` since it doesn't make sense to have a cancel button in this case).

I'm already using this PR from my fork, but it would be great if this can be landed on the library. Please consider this, or let me know any feedback you have, or missing piece on this PR.

Thanks!